### PR TITLE
Bug fix: corrected monitorIdx type

### DIFF
--- a/IDesktopWallpaper/src/main/java/eu/doppel_helix/dev/blaesing/IDesktopWallpaper/DesktopWallpaper.java
+++ b/IDesktopWallpaper/src/main/java/eu/doppel_helix/dev/blaesing/IDesktopWallpaper/DesktopWallpaper.java
@@ -162,11 +162,11 @@ public class DesktopWallpaper extends Unknown {
         }
     }
 
-    public void SetWallpaper(String monitorIdx, String path) {
-        WString wMonitorIdx = new WString(monitorIdx);
+    public void SetWallpaper(String monitorId, String path) {
+        WString wMonitorId = new WString(monitorId);
         WString wstring = new WString(path);
         HRESULT result = (HRESULT) this._invokeNativeObject(VTABLE_ID_SET_WALLPAPER,
-                new Object[]{this.getPointer(), wMonitorIdx, wstring},
+                new Object[]{this.getPointer(), wMonitorId, wstring},
                 HRESULT.class);
         COMUtils.checkRC(result);
     }

--- a/IDesktopWallpaper/src/main/java/eu/doppel_helix/dev/blaesing/IDesktopWallpaper/DesktopWallpaper.java
+++ b/IDesktopWallpaper/src/main/java/eu/doppel_helix/dev/blaesing/IDesktopWallpaper/DesktopWallpaper.java
@@ -162,10 +162,11 @@ public class DesktopWallpaper extends Unknown {
         }
     }
 
-    public void SetWallpaper(int monitorIdx, String path) {
+    public void SetWallpaper(String monitorIdx, String path) {
+        WString wMonitorIdx = new WString(monitorIdx);
         WString wstring = new WString(path);
         HRESULT result = (HRESULT) this._invokeNativeObject(VTABLE_ID_SET_WALLPAPER,
-                new Object[]{this.getPointer(), monitorIdx, wstring},
+                new Object[]{this.getPointer(), wMonitorIdx, wstring},
                 HRESULT.class);
         COMUtils.checkRC(result);
     }


### PR DESCRIPTION
First of all: I just noticed that you uploaded the IDesktopWallpaper sample just today (just for me?) so I wanted to thank you again. I noticed that there might be a bug in the SetWallpaper method as it should take in input the monitorIdx as a string, as stated [here](https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-idesktopwallpaper-setwallpaper). 
Hope that this will help you
